### PR TITLE
CORS 제거

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,14 +43,6 @@ FastAPIInstrumentor.instrument_app(app)
 instrumentator = Instrumentator()
 instrumentator.instrument(app).expose(app)
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"], # TODO: 허용하는 URL 넣어야함
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 app.mount("/static", StaticFiles(directory="static"), name="static")
 @app.get("/favicon.ico")
 async def favicon():


### PR DESCRIPTION
API Gateway에서 CORS를 처리하므로 CORS 설정할 필요 없음.